### PR TITLE
Add support for Linux 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ gem 'phony_rails'
 # Twilio REST API.
 gem 'twilio-ruby', '~> 5.46'
 
+gem 'pry-rails'
+
 group :development, :test do
   gem 'mocha'
   gem 'sqlite3'
@@ -27,7 +29,6 @@ end
 
 group :development do
   gem 'listen'
-  gem 'pry-rails'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,8 @@ GEM
     nio4r (2.5.7)
     nokogiri (1.11.2-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.11.2-x86_64-linux)
+      racc (~> 1.4)
     pg (1.2.3)
     phony (2.18.21)
     phony_rails (0.14.13)
@@ -197,6 +199,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-linux
 
 DEPENDENCIES
   dotenv-rails

--- a/app.json
+++ b/app.json
@@ -17,6 +17,10 @@
   "repository": "https://github.com/TwilioDevEd/clicktocall-rails",
   "logo": "https://s3-us-west-2.amazonaws.com/deved/twilio-logo.png",
   "success_url": "/landing.html",
+  "buildpacks": [
+    { "url": "heroku/nodejs" },
+    { "url": "heroku/ruby" }
+  ],
   "env": {
     "TWILIO_ACCOUNT_SID": {
       "description": "Your Twilio account secret ID, you can find at: https://www.twilio.com/user/account",


### PR DESCRIPTION
While trying to deploy to Heroku, I notice we missed compatibility on Gemfile.lock for `x86_64-linux` platform.